### PR TITLE
phanyzewski/monitoring for allowed/blocked ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Run the client specifying an email address you want to associate the data with
 
 |        Name                        |      Description                          |                   Default                                    |
 |------------------------------------|-------------------------------------------|--------------------------------------------------------------|
+| `ALLOW_IPS`                        | configures allowed ips for speed tests    | `""`                                                         |
+| `BLOCK_IPS`                        | configures blocked ips for speed tests    | `""`                                                         |
 | `ENVIRONMENT`                      | controls log output                       | `"production"`                                               |
 | `IMUP_ADDRESS`                     | imup API address                          | `"https://api.imup.io/v1/data/connectivity"`                 |
 | `IMUP_ADDRESS_SPEEDTEST`           | imup API address for speedtest            | `"https://api.imup.io/v1/data/speedtest"`                    |

--- a/config/config.go
+++ b/config/config.go
@@ -176,6 +176,7 @@ func Reload(data []byte) (Reloadable, error) {
 	return cfg, nil
 }
 
+// DiscoverGateway provides for automatic gateway discovery
 func (c *config) DiscoverGateway() string {
 	if g, err := gw.DiscoverGateway(); err != nil || c.NoDiscoverGateway {
 		return ""
@@ -192,42 +193,49 @@ func (cfg *config) validate() error {
 	return nil
 }
 
+// APIKey is an organization API key used for imUp.io's org product
 func (c *config) APIKey() string {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.Key
 }
 
+// HostID is the configured or local host id to associate test data with
 func (c *config) HostID() string {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.ID
 }
 
+// EmailAddress the email address to associate test data with
 func (c *config) EmailAddress() string {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.Email
 }
 
+// Env production or development, used for realtime error tracking
 func (c *config) Env() string {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.Environment
 }
 
+// GroupID is the logical name for a group of org hosts
 func (c *config) GroupID() string {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.GID
 }
 
+// Group is the human readable name for a group of org hosts
 func (c *config) Group() string {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.GroupName
 }
 
+// Version returns the current version of package config
 func (c *config) Version() string {
 	mu.RLock()
 	defer mu.RUnlock()
@@ -241,54 +249,63 @@ func (c *config) Version() string {
 // 	return c.LogDirectory
 // }
 
+// Realtime boolean indicating wether or not realtime features should be used
 func (c *config) Realtime() bool {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.RealtimeEnabled
 }
 
+// DevelopmentEnvironment turns verbose logging on for some functions
 func (c *config) DevelopmentEnvironment() bool {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.Environment == "development"
 }
 
+// DisableRealtime turns off the imUp.io realtime feature set
 func (c *config) DisableRealtime() {
 	mu.Lock()
 	defer mu.Unlock()
 	c.RealtimeEnabled = false
 }
 
+// EnableRealtime enables the imUp.io realtime feature set
 func (c *config) EnableRealtime() {
 	mu.Lock()
 	defer mu.Unlock()
 	c.RealtimeEnabled = true
 }
 
+// StoreJobsOnDisk allows for extra redundancy between test by not caching test data in memory
 func (c *config) StoreJobsOnDisk() bool {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.Nonvolatile
 }
 
+// SpeedTests allow client to periodically run speed tests, per the NDT7 specification
 func (c *config) SpeedTests() bool {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.SpeedTestEnabled
 }
 
+// InsecureSpeedTests ndt7 configurable field
 func (c *config) InsecureSpeedTests() bool {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.InsecureSpeedTest
 }
 
+// QuietSpeedTests suppress speed test output
 func (c *config) QuietSpeedTests() bool {
 	mu.RLock()
 	defer mu.RUnlock()
 	return c.QuietSpeedTest
 }
 
+// PingTests determines if connectivity should use ICMP requests
 func (c *config) PingTests() bool {
 	mu.RLock()
 	defer mu.RUnlock()

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/honeybadger-io/honeybadger-go v0.5.0
 	github.com/jackpal/gateway v1.0.7
+	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/m-lab/ndt7-client-go v0.7.0
 	github.com/matryer/is v1.4.0
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/imup-io/client
 go 1.19
 
 require (
-	github.com/hashicorp/go-retryablehttp v0.7.1
+	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/honeybadger-io/honeybadger-go v0.5.0
 	github.com/jackpal/gateway v1.0.7
 	github.com/jellydator/ttlcache/v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/jackpal/gateway v1.0.7
 	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/m-lab/ndt7-client-go v0.7.0
-	github.com/matryer/is v1.4.0
+	github.com/matryer/is v1.4.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/prometheus-community/pro-bing v0.1.0
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/hashicorp/go-hclog v0.12.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
 github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
+github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/honeybadger-io/honeybadger-go v0.5.0 h1:aB+rWcUZ1uaOxxbgX2Dazir+vodrMNlWGEp8fd0ttv0=

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,8 @@ github.com/m-lab/uuid-annotator v0.4.1/go.mod h1:f/zvgcc5A3HQ1Y63HWpbBVXNcsJwQ4u
 github.com/m-lab/uuid-annotator v0.4.5 h1:YSgAwaYqgJ85Al+40DEc3NGBaL1t4TiZatdzXgFNTTI=
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
 github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
+github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
+github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/go.sum
+++ b/go.sum
@@ -146,15 +146,12 @@ github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.12.2 h1:F1fdYblUEsxKiailtkhCCG2g4bipEgaHiDc8vffNpD4=
 github.com/hashicorp/go-hclog v0.12.2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-retryablehttp v0.7.1 h1:sUiuQAnLlbvmExtFQs72iFW/HXeUn8Z1aJLQ4LJJbTQ=
-github.com/hashicorp/go-retryablehttp v0.7.1/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
 github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -207,8 +204,6 @@ github.com/m-lab/uuid v0.0.0-20191115203855-549727171666/go.mod h1:pOwFpWLKhWzvB
 github.com/m-lab/uuid v1.0.1 h1:+Ku1MQUL9gkSk+eQjLej8qKKtBvAnvZb3TB7QtSP+bw=
 github.com/m-lab/uuid-annotator v0.4.1/go.mod h1:f/zvgcc5A3HQ1Y63HWpbBVXNcsJwQ4uRIOqsF/nyto8=
 github.com/m-lab/uuid-annotator v0.4.5 h1:YSgAwaYqgJ85Al+40DEc3NGBaL1t4TiZatdzXgFNTTI=
-github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
-github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/matryer/is v1.4.1 h1:55ehd8zaGABKLXQUe2awZ99BD/PTc2ls+KV/dXphgEQ=
 github.com/matryer/is v1.4.1/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jackpal/gateway v1.0.7 h1:7tIFeCGmpyrMx9qvT0EgYUi7cxVW48a0mMvnIL17bPM=
 github.com/jackpal/gateway v1.0.7/go.mod h1:aRcO0UFKt+MgIZmRmvOmnejdDT4Y1DNiNOsSd1AcIbA=
+github.com/jellydator/ttlcache/v3 v3.0.1 h1:cHgCSMS7TdQcoprXnWUptJZzyFsqs18Lt8VVhRuZYVU=
+github.com/jellydator/ttlcache/v3 v3.0.1/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -307,6 +309,7 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
+go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/imup.go
+++ b/imup.go
@@ -64,7 +64,6 @@ type pingStats struct {
 type imup struct {
 	APIPostConnectionData        string
 	APIPostSpeedTestData         string
-	ExternalIPAddress            string
 	LivenessCheckInAddress       string
 	PingAddressesExternal        string
 	PingAddressInternal          string

--- a/imup.go
+++ b/imup.go
@@ -64,6 +64,7 @@ type pingStats struct {
 type imup struct {
 	APIPostConnectionData        string
 	APIPostSpeedTestData         string
+	ExternalIPAddress            string
 	LivenessCheckInAddress       string
 	PingAddressesExternal        string
 	PingAddressInternal          string

--- a/run.go
+++ b/run.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/imup-io/client/util"
+	"github.com/jellydator/ttlcache/v3"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -34,6 +35,37 @@ func run(ctx context.Context, shutdown chan os.Signal) error {
 		}
 		clearCache()
 	}
+
+	// ======================================================================
+	// Public IP Address
+	//
+	// create an in memory cache for storing the clients public IP address
+	cache := ttlcache.New[string, string]()
+
+	// refresh public ip address every 15 minutes
+	go func() {
+		ticker := time.NewTicker((15 * time.Minute))
+		defer ticker.Stop()
+
+		for {
+			// only fetch a clients public ip address if configured to allow/block specific ips
+			if len(imup.cfg.AllowedIPs()) > 0 || len(imup.cfg.BlockedIPs()) > 0 {
+				if ip, err := util.PublicIP(); err != nil {
+					log.Error(err)
+					imup.Errors.write("IdentifyPublicIP", err)
+				} else {
+					cache.Set("PublicIP", ip, ttlcache.NoTTL)
+				}
+			}
+
+			select {
+			case <-ticker.C:
+				continue
+			case <-cctx.Done():
+				return
+			}
+		}
+	}()
 
 	// ======================================================================
 	// Authorization
@@ -71,38 +103,14 @@ func run(ctx context.Context, shutdown chan os.Signal) error {
 		defer ticker.Stop()
 		for {
 			if imup.cfg.SpeedTests() {
-				allowed := true
-				blocked := false
-
-				if len(imup.cfg.AllowedIPs()) > 0 || len(imup.cfg.BlockedIPs()) > 0 {
-					if ip, err := util.PublicIP(); err != nil {
-						log.Error(err)
-						imup.Errors.write("IdentifyPublicIP", err)
-					} else {
-						// iterate over list of allowed ips and ensure the public ip is a match
-						for _, v := range imup.cfg.AllowedIPs() {
-							if ip == v {
-								allowed = true
-								return
-							}
-
-							allowed = false
-						}
-
-						// iterate over list of blocked ips and ensure the public ip is not a match
-						for _, v := range imup.cfg.BlockedIPs() {
-							if ip == v {
-								blocked = true
-								return
-							}
-
-							blocked = false
-						}
-					}
+				monitoring := true
+				if item := cache.Get("PublicIP"); item != nil {
+					ip := item.Value()
+					monitoring = util.IPMonitored(ip, imup.cfg.AllowedIPs(), imup.cfg.BlockedIPs())
 				}
 
 				// extra check if ip based speed testing is configured
-				if allowed && !blocked {
+				if monitoring {
 					if err := imup.runSpeedTest(cctx); err != nil {
 						log.Error(err)
 						imup.Errors.write("CollectSpeedTestData", err)
@@ -144,22 +152,31 @@ func run(ctx context.Context, shutdown chan os.Signal) error {
 		ticker := time.NewTicker(tester.Interval())
 		defer ticker.Stop()
 		for {
-			collected := tester.Collect(cctx, strings.Split(imup.PingAddressesExternal, ","))
-			data = append(data, collected...)
-			log.Debugf("data points collected: %v", len(data))
+			monitoring := true
+			if item := cache.Get("PublicIP"); item != nil {
+				ip := item.Value()
+				monitoring = util.IPMonitored(ip, imup.cfg.AllowedIPs(), imup.cfg.BlockedIPs())
+			}
 
-			if imup.cfg.StoreJobsOnDisk() {
-				sc, dt := tester.DetectDowntime(data)
-				toUserCache(sendDataJob{
-					IMUPAddress: imup.APIPostConnectionData,
-					IMUPData: imupData{
-						Downtime:      dt,
-						StatusChanged: sc,
-						Email:         imup.cfg.EmailAddress(),
-						ID:            imup.cfg.HostID(),
-						Key:           imup.cfg.APIKey(),
-						IMUPData:      collected,
-					}})
+			if monitoring {
+
+				collected := tester.Collect(cctx, strings.Split(imup.PingAddressesExternal, ","))
+				data = append(data, collected...)
+				log.Debugf("data points collected: %v", len(data))
+
+				if imup.cfg.StoreJobsOnDisk() {
+					sc, dt := tester.DetectDowntime(data)
+					toUserCache(sendDataJob{
+						IMUPAddress: imup.APIPostConnectionData,
+						IMUPData: imupData{
+							Downtime:      dt,
+							StatusChanged: sc,
+							Email:         imup.cfg.EmailAddress(),
+							ID:            imup.cfg.HostID(),
+							Key:           imup.cfg.APIKey(),
+							IMUPData:      collected,
+						}})
+				}
 			}
 
 			if len(data) >= imup.IMUPDataLength {

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,9 @@
 package util
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
 	"os"
 	"strconv"
 )
@@ -35,4 +38,27 @@ func GetEnv(varName, defaultVal string) string {
 	}
 
 	return defaultVal
+}
+
+func PublicIP() (string, error) {
+	req, err := http.Get("https: //api.ipify.org?format=json/")
+	if err != nil {
+		return "", err
+	}
+	defer req.Body.Close()
+
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return "", err
+	}
+
+	type IP struct {
+		IP string `json:"ip"`
+	}
+	var ip IP
+	if err := json.Unmarshal(body, &ip); err != nil {
+		return "", err
+	}
+
+	return ip.IP, nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -40,6 +40,7 @@ func GetEnv(varName, defaultVal string) string {
 	return defaultVal
 }
 
+// PublicIP uses an open api to retrieve the clients public ip address
 func PublicIP() (string, error) {
 	req, err := http.Get("https: //api.ipify.org?format=json/")
 	if err != nil {
@@ -61,4 +62,49 @@ func PublicIP() (string, error) {
 	}
 
 	return ip.IP, nil
+}
+
+// IPMonitored considers configured allowed and blocked ip addresses and inspects a clients
+// public ip address to determine if it should be used for speed and connectivity testing
+func IPMonitored(publicIP string, allowed, blocked []string) bool {
+	return ipAllowed(publicIP, allowed) && !ipBlocked(publicIP, blocked)
+}
+
+// iterate over list of allowed ips and ensure the public ip is a match
+func ipAllowed(publicIP string, ips []string) bool {
+	allowed := true
+	for _, v := range ips {
+		if v == "" {
+			continue
+		}
+
+		if publicIP == v {
+			allowed = true
+			return true
+		}
+
+		allowed = false
+	}
+
+	return allowed
+}
+
+// iterate over list of blocked ips and ensure the public ip is not a match
+func ipBlocked(publicIP string, ips []string) bool {
+	blocked := false
+
+	for _, v := range ips {
+		if v == "" {
+			continue
+		}
+
+		if publicIP == v {
+			blocked = true
+			break
+		}
+
+		blocked = false
+	}
+
+	return blocked
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/imup-io/client/config"
 	"github.com/imup-io/client/util"
 	"github.com/matryer/is"
 )
@@ -43,4 +44,22 @@ func Test_BooleanValueOr(t *testing.T) {
 	boolean = &ptr
 	pbv := util.BooleanValueOr(boolean, "BOOL_ENV", "false")
 	is.Equal(pbv, true)
+}
+
+func Test_IPMonitored(t *testing.T) {
+	is := is.New(t)
+	os.Setenv("EMAIL", "test@example.com")
+	cfg, err := config.New()
+	is.NoErr(err)
+	is.Equal(true, util.IPMonitored("10.0.0.1", cfg.AllowedIPs(), cfg.BlockedIPs()))
+
+	os.Setenv("BLOCK_IPS", "127.0.0.1")
+	cfg, err = config.New()
+	is.NoErr(err)
+	is.Equal(false, util.IPMonitored("127.0.0.1", cfg.AllowedIPs(), cfg.BlockedIPs()))
+
+	os.Setenv("ALLOW_IPS", "192.168.1.1")
+	cfg, err = config.New()
+	is.NoErr(err)
+	is.Equal(true, util.IPMonitored("192.168.1.1", cfg.AllowedIPs(), cfg.BlockedIPs()))
 }

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -49,17 +49,22 @@ func Test_BooleanValueOr(t *testing.T) {
 func Test_IPMonitored(t *testing.T) {
 	is := is.New(t)
 	os.Setenv("EMAIL", "test@example.com")
+
 	cfg, err := config.New()
 	is.NoErr(err)
 	is.Equal(true, util.IPMonitored("10.0.0.1", cfg.AllowedIPs(), cfg.BlockedIPs()))
-
-	os.Setenv("BLOCK_IPS", "127.0.0.1")
-	cfg, err = config.New()
-	is.NoErr(err)
-	is.Equal(false, util.IPMonitored("127.0.0.1", cfg.AllowedIPs(), cfg.BlockedIPs()))
+	is.Equal(true, util.IPMonitored("127.0.0.1", cfg.AllowedIPs(), cfg.BlockedIPs()))
 
 	os.Setenv("ALLOW_IPS", "192.168.1.1")
 	cfg, err = config.New()
 	is.NoErr(err)
 	is.Equal(true, util.IPMonitored("192.168.1.1", cfg.AllowedIPs(), cfg.BlockedIPs()))
+	is.Equal(false, util.IPMonitored("127.0.0.1", cfg.AllowedIPs(), cfg.BlockedIPs()))
+
+	os.Setenv("BLOCK_IPS", "127.0.0.1, 1.1.1.1")
+	cfg, err = config.New()
+	is.NoErr(err)
+	is.Equal(true, util.IPMonitored("192.168.1.1", cfg.AllowedIPs(), cfg.BlockedIPs()))
+	is.Equal(false, util.IPMonitored("127.0.0.1", cfg.AllowedIPs(), cfg.BlockedIPs()))
+
 }


### PR DESCRIPTION
- chore(doc): document interface definitions for config
- feat: implement allow/block lists for speed testing
- feat: extend ip allowing/blocking to connectivity testing
- dependency updates for is & http-retryable
