### PR TITLE
phanyzewski/cidr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION_TAG="1.19-alpine"
+ARG GO_VERSION_TAG="1.20-alpine"
 FROM golang:${GO_VERSION_TAG} as build
 
 WORKDIR /go/src/github.com/imup-io/client

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -111,3 +111,16 @@ func Test_RealtimeOnOff(t *testing.T) {
 	_, _ = disable, disabled
 	_, _ = enable, enabled
 }
+
+func Test_ListedIPs(t *testing.T) {
+	is := is.New(t)
+	os.Setenv("API_KEY", "ApiKey")
+	os.Setenv("EMAIL", "Email")
+	os.Setenv("HOST_ID", "HostID")
+	os.Setenv("ALLOWLISTED_IPS", "10.0.0.0/28,192.168.1.1")
+
+	defaultConfig, err := New()
+	is.NoErr(err)
+
+	is.Equal(len(defaultConfig.AllowedIPs()), 17)
+}

--- a/util/util.go
+++ b/util/util.go
@@ -42,7 +42,7 @@ func GetEnv(varName, defaultVal string) string {
 
 // PublicIP uses an open api to retrieve the clients public ip address
 func PublicIP() (string, error) {
-	req, err := http.Get("https://api.ipify.org?format=json")
+	req, err := http.Get("https://api64.ipify.org?format=json")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
- fix: use the unified ipify endpoint to return ipv6 as well as ipv4 addresses
- feat: extend our allow and block listed ip configuration to calculate ips when a range (CIDR) is available
- wip: this will be implemented prior to this PR in #49
- fix: update dockerfile to match current go version
