### PR TITLE
phanyzewski/config public ips

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ with running the existing testing suite in github actions, however this is the p
 current (as of this commit) coverage.
 
 ```sh
-ok   github.com/imup-io/client 62.961s coverage: 71.4% of statements
-ok   github.com/imup-io/client/config 0.268s coverage: 76.4% of statements
-ok   github.com/imup-io/client/util 0.603s coverage: 86.4% of statements
+ok   github.com/imup-io/client 62.961s coverage: 72.1% of statements
+ok   github.com/imup-io/client/config 0.268s coverage: 77.1% of statements
+ok   github.com/imup-io/client/util 0.603s coverage: 90.6% of statements
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/imup-io/client/util"
 	gw "github.com/jackpal/gateway"
-	"golang.org/x/exp/slog"
 	log "golang.org/x/exp/slog"
 )
 
@@ -402,7 +401,7 @@ func ips(ips []string) []string {
 		}
 
 		if ipAddr, ipNet, err := net.ParseCIDR(ip); err != nil {
-			slog.Warn("cannot parse as cidr, assuming individual ip address", ip, err)
+			log.Warn("cannot parse as cidr, assuming individual ip address", ip, err)
 			hosts = append(hosts, ip)
 		} else {
 			for ip := ipAddr.Mask(ipNet.Mask); ipNet.Contains(ip); incrementIPs(ip) {

--- a/config/config.go
+++ b/config/config.go
@@ -190,6 +190,7 @@ func Reload(data []byte) (Reloadable, error) {
 	}
 
 	mu.Lock()
+	log.Info("imup config reloaded", "config", fmt.Sprintf("config: %+v", c.CFG))
 	cfg = c.CFG
 	defer mu.Unlock()
 	return cfg, nil

--- a/config/config.go
+++ b/config/config.go
@@ -123,8 +123,8 @@ func New() (Reloadable, error) {
 		configVersion = flag.String("config-version", "", "config version")
 		email = flag.String("email", "", "email address")
 		environment = flag.String("environment", "", "imUp environment (development, production)")
-		groupID = flag.String("groupID", "", "org users group id")
-		groupName = flag.String("groupName", "", "org users group name")
+		groupID = flag.String("group-id", "", "org users group id")
+		groupName = flag.String("group-name", "", "org users group name")
 		id = flag.String("id", "", "host id")
 		// TODO: implement an app wide file logger
 		// logDirectory = flag.String("log-directory", "", "path to imUp log directory on filesystem")

--- a/config/config.go
+++ b/config/config.go
@@ -78,9 +78,9 @@ type Reloadable interface {
 var cfg *config
 
 type config struct {
-	ID    string
-	Email string
-	Key   string
+	id    string
+	email string
+	key   string
 
 	ConfigVersion string `json:"version"`
 	Environment   string `json:"environment"`
@@ -136,17 +136,17 @@ func New() (Reloadable, error) {
 
 	hostname, _ := os.Hostname()
 
-	cfg.ID = util.ValueOr(id, "HOST_ID", hostname)
+	cfg.id = util.ValueOr(id, "HOST_ID", hostname)
 	// TODO: implement an app wide file logger
 	// cfg.LogDirectory = argOrEnvVar(logDirectory, "IMUP_LOG_DIRECTORY", "")
 	cfg.AllowlistedIPs = strings.Split(util.ValueOr(allowlistedIPs, "ALLOWLISTED_IPS", ""), ",")
 	cfg.BlocklistedIPs = strings.Split(util.ValueOr(blocklistedIPs, "BLOCKLISTED_IPS", ""), ",")
 	cfg.ConfigVersion = util.ValueOr(configVersion, "CONFIG_VERSION", "dev-preview")
-	cfg.Email = util.ValueOr(email, "EMAIL", "unknown")
+	cfg.email = util.ValueOr(email, "EMAIL", "unknown")
 	cfg.Environment = util.ValueOr(environment, "ENVIRONMENT", "production")
 	cfg.GID = util.ValueOr(groupID, "GROUP_ID", "production")
 	cfg.GroupName = util.ValueOr(groupName, "GROUP_NAME", "production")
-	cfg.Key = util.ValueOr(apiKey, "API_KEY", "")
+	cfg.key = util.ValueOr(apiKey, "API_KEY", "")
 
 	cfg.SpeedTestEnabled = !util.BooleanValueOr(noSpeedTest, "NO_SPEED_TEST", "false")
 	cfg.InsecureSpeedTest = util.BooleanValueOr(insecureSpeedTest, "INSECURE_SPEED_TEST", "false")
@@ -175,9 +175,9 @@ func Reload(data []byte) (Reloadable, error) {
 		return nil, fmt.Errorf("configuration matches existing config")
 	}
 
-	c.CFG.Email = cfg.Email
-	c.CFG.ID = cfg.ID
-	c.CFG.Key = cfg.Key
+	c.CFG.email = cfg.email
+	c.CFG.id = cfg.id
+	c.CFG.key = cfg.key
 
 	if err := c.CFG.validate(); err != nil {
 		return nil, fmt.Errorf("invalid configuration: %v", err)
@@ -199,8 +199,8 @@ func (c *config) DiscoverGateway() string {
 }
 
 func (cfg *config) validate() error {
-	if (cfg.Email == "unknown" || cfg.Email == "") && (cfg.Key == "" || cfg.ID == "") {
-		return fmt.Errorf("please supply an email address (--email) or api key and host id (--key, --id)!: email: %s, key: %s, id: %s", cfg.Email, cfg.Key, cfg.ID)
+	if (cfg.email == "unknown" || cfg.email == "") && (cfg.key == "" || cfg.id == "") {
+		return fmt.Errorf("please supply an email address (--email) or api key and host id (--key, --id)!: email: %s, key: %s, id: %s", cfg.email, cfg.key, cfg.id)
 	}
 
 	return nil
@@ -210,21 +210,21 @@ func (cfg *config) validate() error {
 func (c *config) APIKey() string {
 	mu.RLock()
 	defer mu.RUnlock()
-	return c.Key
+	return c.key
 }
 
 // HostID is the configured or local host id to associate test data with
 func (c *config) HostID() string {
 	mu.RLock()
 	defer mu.RUnlock()
-	return c.ID
+	return c.id
 }
 
 // EmailAddress the email address to associate test data with
 func (c *config) EmailAddress() string {
 	mu.RLock()
 	defer mu.RUnlock()
-	return c.Email
+	return c.email
 }
 
 // Env production or development, used for realtime error tracking

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -124,3 +124,17 @@ func Test_ListedIPs(t *testing.T) {
 
 	is.Equal(len(defaultConfig.AllowedIPs()), 17)
 }
+
+func Test_PublicIP(t *testing.T) {
+	is := is.New(t)
+	os.Setenv("API_KEY", "ApiKey")
+	os.Setenv("EMAIL", "Email")
+	os.Setenv("HOST_ID", "HostID")
+
+	defaultConfig, err := New()
+	is.NoErr(err)
+
+	ip := defaultConfig.RefreshPublicIP()
+	is.True(ip != "")
+	is.Equal(defaultConfig.PublicIP(), ip)
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,7 +39,7 @@ func Test_ConfigReloadable(t *testing.T) {
 	os.Setenv("EMAIL", "Email")
 	os.Setenv("HOST_ID", "HostID")
 
-	newConfig := &config{PingEnabled: true, Key: "some key", ID: "some id", ConfigVersion: "new-new"}
+	newConfig := &config{PingEnabled: true, key: "some key", id: "some id", ConfigVersion: "new-new"}
 	var b bytes.Buffer
 	json.NewEncoder(&b).Encode(struct {
 		C *config `json:"config"`
@@ -66,7 +66,7 @@ func Test_ConfigReloadableThreadSafe(t *testing.T) {
 	is.Equal(false, defaultConfig.PingTests())
 	write := func() {
 		var b bytes.Buffer
-		newConfig := &config{PingEnabled: true, Key: "some key", ID: "some id"}
+		newConfig := &config{PingEnabled: true, key: "some key", id: "some id"}
 		json.NewEncoder(&b).Encode(newConfig)
 		cfg, err := Reload(b.Bytes())
 		is.NoErr(err)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.2
 	github.com/honeybadger-io/honeybadger-go v0.5.0
 	github.com/jackpal/gateway v1.0.7
-	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/m-lab/ndt7-client-go v0.7.0
 	github.com/matryer/is v1.4.1
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,6 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jackpal/gateway v1.0.7 h1:7tIFeCGmpyrMx9qvT0EgYUi7cxVW48a0mMvnIL17bPM=
 github.com/jackpal/gateway v1.0.7/go.mod h1:aRcO0UFKt+MgIZmRmvOmnejdDT4Y1DNiNOsSd1AcIbA=
-github.com/jellydator/ttlcache/v3 v3.0.1 h1:cHgCSMS7TdQcoprXnWUptJZzyFsqs18Lt8VVhRuZYVU=
-github.com/jellydator/ttlcache/v3 v3.0.1/go.mod h1:WwTaEmcXQ3MTjOm4bsZoDFiCu/hMvNWLO1w67RXz6h4=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -307,7 +305,6 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
-go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/imup.go
+++ b/imup.go
@@ -153,6 +153,9 @@ func newApp() *imup {
 	// make a channel with a capacity of 300.
 	imup.ChannelImupData = make(chan sendDataJob, 300)
 
+	// on startup get a clients public ip address
+	imup.cfg.RefreshPublicIP()
+
 	return imup
 }
 

--- a/pingtest.go
+++ b/pingtest.go
@@ -246,12 +246,12 @@ func (p *pingTest) setupExternalPinger(ctx context.Context, pingAddrs []string, 
 func (p *pingTest) run(ctx context.Context, pinger *ping.Pinger) (*ping.Statistics, error) {
 	pinger.Debug = true
 	pinger.OnRecv = func(pkt *ping.Packet) {
-		log.Debug("pinger onRecv", fmt.Sprintf("%d bytes sent %s: icmp_seq=%d time=%v\n", pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt))
+		log.Debug("pinger onRecv", fmt.Sprintf("%d bytes sent %s: icmp_seq=%d time=%v", pkt.Nbytes, pkt.IPAddr, pkt.Seq, pkt.Rtt))
 	}
 
 	pinger.OnFinish = func(stats *ping.Statistics) {
-		log.Debug("pinger on finish", fmt.Sprintf("\n--- %s ping statistics ---\n", stats.Addr))
-		log.Debug("pinger on finish", fmt.Sprintf("%d packets transmitted, %d packets received, %v%% packet loss\n", stats.PacketsSent, stats.PacketsRecv, stats.PacketLoss))
+		log.Debug("pinger on finish", fmt.Sprintf("--- %s ping statistics ---", stats.Addr))
+		log.Debug("pinger on finish", fmt.Sprintf("%d packets transmitted, %d packets received, %v%% packet loss", stats.PacketsSent, stats.PacketsRecv, stats.PacketLoss))
 	}
 
 	// required for linux and windows: https://github.com/sparrc/go-ping/issues/4

--- a/util/util.go
+++ b/util/util.go
@@ -1,9 +1,6 @@
 package util
 
 import (
-	"encoding/json"
-	"io"
-	"net/http"
 	"os"
 	"strconv"
 )
@@ -38,30 +35,6 @@ func GetEnv(varName, defaultVal string) string {
 	}
 
 	return defaultVal
-}
-
-// PublicIP uses an open api to retrieve the clients public ip address
-func PublicIP() (string, error) {
-	req, err := http.Get("https://api64.ipify.org?format=json")
-	if err != nil {
-		return "", err
-	}
-	defer req.Body.Close()
-
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return "", err
-	}
-
-	type IP struct {
-		IP string `json:"ip"`
-	}
-	var ip IP
-	if err := json.Unmarshal(body, &ip); err != nil {
-		return "", err
-	}
-
-	return ip.IP, nil
 }
 
 // IPMonitored considers configured allowed and blocked ip addresses and inspects a clients

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -46,17 +46,6 @@ func Test_BooleanValueOr(t *testing.T) {
 	is.Equal(pbv, true)
 }
 
-func Test_PublicIP(t *testing.T) {
-	is := is.New(t)
-	os.Setenv("EMAIL", "test@example.com")
-	ip, err := util.PublicIP()
-	is.NoErr(err)
-
-	cfg, err := config.New()
-	is.NoErr(err)
-
-	is.Equal(true, util.IPMonitored(ip, cfg.AllowedIPs(), cfg.BlockedIPs()))
-}
 func Test_IPMonitored(t *testing.T) {
 	is := is.New(t)
 	os.Setenv("EMAIL", "test@example.com")


### PR DESCRIPTION
- fix: do not export read-only configuration
- feat: add PublicIP and RefreshPublicIP functions to config
- fix: do not camelCase flags
- chore: use the new publicIP funcitons in config
- feat: fetch a clients public ip address on startup
- feat: realtime first, use public IP from config, remove cache
- chore: remove newlines from log output
- feat: log new configs
