### PR TITLE
remove speed test retry logic

### DIFF
--- a/connectivity/connectivity.go
+++ b/connectivity/connectivity.go
@@ -58,5 +58,6 @@ func pingAddress(addresses []string, avoidAddrs map[string]bool) string {
 		}
 	}
 
+	rand := rand.New(rand.NewSource(int64(time.Now().Nanosecond())))
 	return allowedPingAddrs[rand.Intn(pingAddrCount)]
 }


### PR DESCRIPTION
- removes speed test retry logic until we can spend time making sure it works as intended
- seeds rand before choosing a ping address