### PR TITLE
phanyzewski/configurable speed tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ To configure log verbosity, set the `VERBOSITY` environment variable to one of t
 | `PING_INTERVAL`                    | ping interval in seconds                        | `"60"`                                                       |
 | `PING_REQUESTS`                    | number of requests each test                    | `"600"`                                                      |
 | `REALTIME`                         | enable real-time features if on paid plan       | `"true"`                                                     |
+| `SPEED_TEST_DAILY_TOTAL`           | approximate number of speed test to run per day | `"6"`                                                     |
 | `VERBOSITY`                        | controls log level. must be one of `debug`, `info`, `warn`, `error` | `"info"`                                 |
 
 ## Flags
@@ -180,6 +181,8 @@ Usage: imup
     	api endpoint for imup realtime reloadable configuration, default is https://api.imup.io/v1/realtime/config
   -should-run-speed-test-address string
     	api endpoint for imup realtime speed tests, default is https://api.imup.io/v1/realtime/shouldClientRunSpeedTest
+  -speed-test-daily-total string
+     configure the total number of speed tests to run in a day, [1-32]
   -speed-test-results-address string
     	api endpoint for imup realtime speed test results, default is https://api.imup.io/v1/realtime/speedTestResults
   -speed-test-status-update-address string

--- a/helpers.go
+++ b/helpers.go
@@ -8,18 +8,24 @@ import (
 	"gonum.org/v1/gonum/stat/distuv"
 )
 
-// timePeriodMinutes is the desired interval between tests
-// the default (fixed) configuration is one tests every four hours
-const timePeriodMinutes = 4 * 60
-
 // speedTestInterval takes advantage of a poisson distribution
 // to generate pseudo random speed tests
 // this distribution helps guarantee a consistent number of speed tests
 // with a smaller chance of frequent speed tests consuming large amounts of data
 // or saturating a network
-func speedTestInterval() time.Duration {
+//
+// numTests is the desired number of speed tests to run, within a 24 hour period
+func speedTestInterval(numTests int) time.Duration {
+	if numTests < 1 {
+		numTests = 1
+	}
+
+	if numTests > 32 {
+		numTests = 32
+	}
+
 	t := distuv.Poisson{
-		Lambda: timePeriodMinutes,
+		Lambda: float64(1440 / numTests),
 	}.Rand()
 
 	return time.Duration(t * float64(time.Minute))

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -8,15 +8,15 @@ import (
 
 func Test_SpeedTestFrequency(t *testing.T) {
 	is := is.New(t)
-	hours := 24
-	maxTests := 8
+	minutesInDay := 1440
+	maxTests := 6
 
 	//
 	tf := func() int {
 		numTests := 0
-		for i := 1; i <= hours; {
-			t1 := speedTestInterval()
-			i += int(t1.Hours())
+		for i := 1; i < minutesInDay; {
+			t1 := speedTestInterval(maxTests)
+			i += int(t1.Minutes())
 			numTests++
 		}
 
@@ -24,7 +24,49 @@ func Test_SpeedTestFrequency(t *testing.T) {
 	}
 
 	results := []int{tf(), tf(), tf(), tf(), tf(), tf(), tf(), tf(), tf()}
-	is.True(max(results) <= maxTests)
+	is.True(max(results) <= maxTests+1)
 	is.True(min(results) > maxTests/2)
+}
 
+func Test_MaxSpeedTestFrequency(t *testing.T) {
+	is := is.New(t)
+	minutesInDay := 1440
+	maxTests := 32
+
+	//
+	tf := func() int {
+		numTests := 0
+		for i := 1; i < minutesInDay; {
+			t1 := speedTestInterval(maxTests)
+			i += int(t1.Minutes())
+			numTests++
+		}
+
+		return numTests
+	}
+
+	results := []int{tf(), tf(), tf(), tf(), tf(), tf(), tf(), tf(), tf()}
+	is.True(max(results) <= maxTests+2)
+	is.True(min(results) > maxTests/2)
+}
+
+func Test_MinSpeedTestFrequency(t *testing.T) {
+	is := is.New(t)
+	minutesInDay := 1440
+	minTests := 1
+
+	//
+	tf := func() int {
+		numTests := 0
+		for i := 1; i < minutesInDay; {
+			t1 := speedTestInterval(minTests)
+			i += int(t1.Minutes())
+			numTests++
+		}
+
+		return numTests
+	}
+
+	results := []int{tf(), tf(), tf(), tf(), tf(), tf(), tf(), tf(), tf()}
+	is.True(max(results) <= minTests+1)
 }

--- a/run.go
+++ b/run.go
@@ -229,7 +229,7 @@ func run(ctx context.Context, shutdown chan os.Signal) error {
 	// collects speed test data using the ndt7 protocol
 	// data is collected pseudo randomly, every 4 hours
 	go func() {
-		ticker := time.NewTicker(speedTestInterval())
+		ticker := time.NewTicker(speedTestInterval(imup.cfg.SpeedTestDaily()))
 		defer ticker.Stop()
 		for {
 			if imup.cfg.SpeedTests() {


### PR DESCRIPTION
- feat: allow the number of speed tests ran daily to be configurable
- feat: update helper utility for creating pseudo random sleep times to use the new config
